### PR TITLE
Fix lazy MIDI connection reporting + constrain cryptography<49

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,12 @@ fl-studio-mcp = "fl_studio_mcp.server:main"
 [tool.hatch.build.targets.wheel]
 packages = ["src/fl_studio_mcp"]
 
+[tool.uv]
+# cryptography >=49 ships macOS wheels for arm64 only; on Intel Macs it falls
+# back to a source build (needs Rust + OpenSSL). 48.x still has universal2
+# wheels and satisfies joserfc's cryptography>=45.0.1 requirement.
+constraint-dependencies = ["cryptography<49"]
+
 [dependency-groups]
 dev = [
     "fl-studio-api-stubs>=37.0",

--- a/src/fl_studio_mcp/server.py
+++ b/src/fl_studio_mcp/server.py
@@ -104,10 +104,11 @@ def fl_connect() -> str:
     reset_connection()
 
     conn = get_connection()
-    if conn.is_connected:
-        return "Successfully connected to FL Studio via MIDI!"
-    else:
-        return f"Connection failed: {conn.connection_error}"
+    try:
+        conn.ensure_connected()
+    except RuntimeError as e:
+        return f"Connection failed: {e}"
+    return "Successfully connected to FL Studio via MIDI!"
 
 
 @mcp.tool()
@@ -118,6 +119,12 @@ def fl_connection_status() -> dict:
     and any error messages if not.
     """
     conn = get_connection()
+    # Eagerly attempt a connection so the reported status reflects actual
+    # reachability rather than the lazily-initialized flag.
+    try:
+        conn.ensure_connected()
+    except RuntimeError:
+        pass
     status = conn.get_status()
     return {
         "connected": status.get("connected", False),


### PR DESCRIPTION
This PR contains two changes.

## 1. Make fl_connect/fl_connection_status actually attempt a connection

**Why:** The MIDI port to FL Studio is opened lazily — only on the first real command (`send_command → ensure_connected → connect`). But `fl_connect()` and `fl_connection_status()` just read the `is_connected` flag without ever triggering a connect. So until some other command ran, both tools reported `connected: false` with `error: null` even when FL Studio was fully reachable (controller enabled on `IAC Driver Bus 1`, status ready), and `fl_connect` returned the meaningless `"Connection failed: None"`.

**Changes:**
- `fl_connect()`: calls `conn.ensure_connected()` and returns the real `RuntimeError` message on failure.
- `fl_connection_status()`: eagerly attempts a connection (swallowing the error) before reading status, so the reported state reflects actual reachability.

## 2. Constrain cryptography<49 for Intel Mac wheels

`cryptography >=49` ships macOS wheels for arm64 only; on Intel Macs it falls back to a source build (needs Rust + OpenSSL). 48.x still has universal2 wheels and satisfies joserfc's `cryptography>=45.0.1` requirement, so the uv constraint pins `cryptography<49` to avoid the source build on x86_64.

## Notes for reviewer

- Verified live that issuing a real command connects over `IAC Driver Bus 1`, which is exactly what the connection tools now do up front.
- The running MCP server must be restarted to pick up the connection-tool change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)