### PR TITLE
Experimental: Support custom FL Studio User data folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ pip install -e .
 
 Copy the controller script to FL Studio's Hardware folder:
 
+> These commands use FL Studio's default User data folder. If you changed it in
+> **Options > File settings**, use the corresponding `FL Studio\Settings` folder
+> under your configured User data folder instead. See [Custom FL Studio User data
+> folder](#custom-fl-studio-user-data-folder).
+
 ```bash
 # macOS
 mkdir -p ~/Documents/Image-Line/FL\ Studio/Settings/Hardware/FLStudioMCP
@@ -188,7 +193,7 @@ copy scripts\ComposeWithLLM.pyscript "%USERPROFILE%\Documents\Image-Line\FL Stud
 1. **Restart FL Studio** (if it's running)
 2. Go to **Options > MIDI Settings**
 3. Under **Input**, find your virtual MIDI port (e.g., "IAC Driver Bus 1")
-4. Set the **Controller type** to **FLStudioMCP**
+4. Set the **Controller type** to **FL Studio MCP Controller**
 5. Enable the port (click to highlight it)
 
 ### 5. Configure Claude (or another MCP client)
@@ -212,6 +217,39 @@ Add to your Claude Desktop config:
 Or for Claude Code, add to your MCP settings (`~/.claude.json`, or run `claude mcp add`).
 
 Using a different MCP-compatible client (Gemini, an OpenAI-based tool, Cursor, etc.)? The same `command`/`args` pair above is all any MCP host needs — add it to that client's own MCP config in whatever format it expects. See [Which AI Clients Work With This?](#which-ai-clients-work-with-this) for what's actually been tested.
+
+### Custom FL Studio User data folder
+
+By default, the MCP server uses FL Studio's standard User data folder:
+`~/Documents/Image-Line` on macOS and `%USERPROFILE%\Documents\Image-Line` on
+Windows. If **Options > File settings > User data folder** points somewhere else,
+install both scripts under that folder and set `FL_STUDIO_USER_DATA_DIR` for the
+MCP server to the configured **Image-Line** directory.
+
+For example, if FL Studio shows `E:\Music\Image-Line` as its User data folder:
+
+```json
+{
+  "mcpServers": {
+    "fl-studio": {
+      "command": "uv",
+      "args": ["run", "--directory", "/path/to/fl-studio-mcp", "fl-studio-mcp"],
+      "env": {
+        "FL_STUDIO_USER_DATA_DIR": "E:\\Music\\Image-Line"
+      }
+    }
+  }
+}
+```
+
+Place the files at:
+
+- `E:\Music\Image-Line\FL Studio\Settings\Hardware\FLStudioMCP\device_FLStudioMCP.py`
+- `E:\Music\Image-Line\FL Studio\Settings\Piano roll scripts\ComposeWithLLM.pyscript`
+
+Restart FL Studio after copying the controller script. The controller resolves
+its active script directory automatically, so the environment variable is only
+required by the MCP server.
 
 ## Usage
 

--- a/fl_controller/device_FLStudioMCP.py
+++ b/fl_controller/device_FLStudioMCP.py
@@ -36,6 +36,10 @@ def _get_script_dir() -> Path:
     FL Studio's Python environment doesn't support __file__, so we construct
     the path based on the platform's standard FL Studio settings location.
     """
+    user_data_dir = os.environ.get("FL_STUDIO_USER_DATA_DIR")
+    if user_data_dir:
+        return Path(user_data_dir) / "FL Studio" / "Settings" / "Hardware" / "FLStudioMCP"
+
     # FL Studio includes the active controller-script folder in sys.path.
     # Prefer it so a custom User data folder works without hard-coded paths.
     for entry in sys.path:
@@ -123,7 +127,10 @@ def execute_pending_command():
 def write_response(response: dict):
     """Write response to JSON file."""
     try:
-        RESPONSE_FILE.write_text(json.dumps(response, indent=2))
+        # pathlib.Path.write_text can fail in FL Studio's embedded Python.
+        # Use the built-in file API with a string path instead.
+        with open(str(RESPONSE_FILE), "w", encoding="utf-8") as response_file:
+            json.dump(response, response_file, indent=2)
     except Exception as e:
         print(f"Error writing response: {e}")
 

--- a/fl_controller/device_FLStudioMCP.py
+++ b/fl_controller/device_FLStudioMCP.py
@@ -36,6 +36,13 @@ def _get_script_dir() -> Path:
     FL Studio's Python environment doesn't support __file__, so we construct
     the path based on the platform's standard FL Studio settings location.
     """
+    # FL Studio includes the active controller-script folder in sys.path.
+    # Prefer it so a custom User data folder works without hard-coded paths.
+    for entry in sys.path:
+        candidate = Path(entry)
+        if candidate.name == "FLStudioMCP" and (candidate / "device_FLStudioMCP.py").exists():
+            return candidate
+
     if sys.platform == "darwin":
         # macOS
         base = Path.home() / "Documents" / "Image-Line" / "FL Studio" / "Settings"

--- a/scripts/ComposeWithLLM.pyscript
+++ b/scripts/ComposeWithLLM.pyscript
@@ -18,6 +18,9 @@ import os
 
 def get_script_dir():
     """Get the directory where this script is located"""
+    user_data_dir = os.environ.get("FL_STUDIO_USER_DATA_DIR")
+    if user_data_dir:
+        return os.path.join(user_data_dir, "FL Studio", "Settings", "Piano roll scripts")
     return os.path.expanduser("~/Documents/Image-Line/FL Studio/Settings/Piano roll scripts")
 
 

--- a/src/fl_studio_mcp/tools/piano_roll.py
+++ b/src/fl_studio_mcp/tools/piano_roll.py
@@ -14,6 +14,7 @@ Communication flow:
 from __future__ import annotations
 
 import json
+import os
 import platform
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -26,13 +27,16 @@ if TYPE_CHECKING:
 
 def _get_fl_scripts_dir() -> Path:
     """Get the FL Studio Piano Roll scripts directory."""
-    system = platform.system()
-
-    if system in ("Darwin", "Windows"):
-        base = Path.home() / "Documents" / "Image-Line" / "FL Studio" / "Settings"
+    user_data_dir = os.environ.get("FL_STUDIO_USER_DATA_DIR")
+    if user_data_dir:
+        base = Path(user_data_dir).expanduser() / "FL Studio" / "Settings"
     else:
-        # Linux fallback (FL Studio doesn't officially support Linux)
-        base = Path.home() / ".fl-studio" / "Settings"
+        system = platform.system()
+        if system in ("Darwin", "Windows"):
+            base = Path.home() / "Documents" / "Image-Line" / "FL Studio" / "Settings"
+        else:
+            # Linux fallback (FL Studio doesn't officially support Linux)
+            base = Path.home() / ".fl-studio" / "Settings"
 
     scripts_dir = base / "Piano roll scripts"
     scripts_dir.mkdir(parents=True, exist_ok=True)

--- a/src/fl_studio_mcp/utils/midi_connection.py
+++ b/src/fl_studio_mcp/utils/midi_connection.py
@@ -14,6 +14,7 @@ instead of keystrokes.
 from __future__ import annotations
 
 import json
+import os
 import platform
 import time
 from pathlib import Path
@@ -22,13 +23,16 @@ from typing import Any
 
 def _get_fl_hardware_dir() -> Path:
     """Get the FL Studio Hardware scripts directory."""
-    system = platform.system()
-
-    if system in ("Darwin", "Windows"):
-        base = Path.home() / "Documents" / "Image-Line" / "FL Studio" / "Settings"
+    user_data_dir = os.environ.get("FL_STUDIO_USER_DATA_DIR")
+    if user_data_dir:
+        base = Path(user_data_dir).expanduser() / "FL Studio" / "Settings"
     else:
-        # Linux fallback
-        base = Path.home() / ".fl-studio" / "Settings"
+        system = platform.system()
+        if system in ("Darwin", "Windows"):
+            base = Path.home() / "Documents" / "Image-Line" / "FL Studio" / "Settings"
+        else:
+            # Linux fallback
+            base = Path.home() / ".fl-studio" / "Settings"
 
     hardware_dir = base / "Hardware" / "FLStudioMCP"
     hardware_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
# Experimental: Support custom FL Studio User data folders

## Summary

This PR adds support for a custom FL Studio User data folder.

- Add the `FL_STUDIO_USER_DATA_DIR` environment variable.
- Use this variable for MIDI controller command and response files.
- Use this variable for Piano Roll request and state files.
- Update the controller script to use the same directory.
- Keep the default Documents directory when the variable is not set.
- Document the custom folder setup and the correct controller name.

## Scope

This PR fixes the confirmed custom-directory paths for the MIDI controller and Piano Roll capabilities.
It does not audit every MCP capability.
Other capabilities can still need custom-directory support.

## Problem

FL Studio can use a User data folder outside the default Documents directory.
The original MCP server always used the default directory.

This caused the MCP server and FL Studio scripts to read different files.
Channel commands timed out. Piano Roll requests stayed in the queue.

## Configuration

Set `FL_STUDIO_USER_DATA_DIR` to the Image-Line directory shown in FL Studio settings.

The following value is only an example:

```json
{
  "env": {
    "FL_STUDIO_USER_DATA_DIR": "E:\\Music\\Image-Line"
  }
}
```

Install the scripts relative to `FL_STUDIO_USER_DATA_DIR`:

- `<FL_STUDIO_USER_DATA_DIR>\FL Studio\Settings\Hardware\FLStudioMCP\device_FLStudioMCP.py`
- `<FL_STUDIO_USER_DATA_DIR>\FL Studio\Settings\Piano roll scripts\ComposeWithLLM.pyscript`

Restart FL Studio after you update the controller script.

## Validation

- Ran `python -m compileall` for the controller and server code.
- Verified that the environment variable resolves the Hardware and Piano Roll directories.
- Verified live channel control through an FL Studio instance with a custom User data folder.
- Verified a 28-note Piano Roll request after the hotkey trigger executed.

## Related issue

Tracks #2 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring a custom FL Studio User data directory through `FL_STUDIO_USER_DATA_DIR`.
  - Improved script and hardware integration when FL Studio is installed in a customized location.
  - Preserved automatic path detection and platform-specific defaults when no custom directory is configured.

- **Documentation**
  - Expanded installation guidance for default and custom FL Studio User data locations.
  - Documented required configuration and script paths.
  - Renamed the controller type to “FL Studio MCP Controller.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->