### PR TITLE
Fix set -e abort in install_mcp_for_claude.sh status check

### DIFF
--- a/scripts/install_mcp_for_claude.sh
+++ b/scripts/install_mcp_for_claude.sh
@@ -123,10 +123,16 @@ EOF
 
 # Show current status
 echo "Current configuration status:"
-check_config_status "$CLAUDE_DESKTOP_CONFIG" "Claude Desktop"
-DESKTOP_CONFIGURED=$?
-check_config_status "$CLAUDE_CODE_CONFIG" "Claude Code"
-CODE_CONFIGURED=$?
+if check_config_status "$CLAUDE_DESKTOP_CONFIG" "Claude Desktop"; then
+    DESKTOP_CONFIGURED=0
+else
+    DESKTOP_CONFIGURED=1
+fi
+if check_config_status "$CLAUDE_CODE_CONFIG" "Claude Code"; then
+    CODE_CONFIGURED=0
+else
+    CODE_CONFIGURED=1
+fi
 echo ""
 
 # Menu


### PR DESCRIPTION
## Summary
- `check_config_status` returns 1 when a Claude config isn't configured yet, which is expected — but under `set -e` a bare call whose exit status is only read afterward via `$?` still trips errexit, aborting the script before it ever reaches the menu that adds the `fl-studio` MCP server entry.
- This means `install.sh` fails on step 5/5 for anyone running it fresh (no existing `fl-studio` entry in `claude_desktop_config.json` / `~/.claude.json`).
- Wraps both status checks in `if/else` so the calls are in a tested context and don't trigger `set -e`.

## Test plan
- [x] `bash -n scripts/install_mcp_for_claude.sh` (syntax check)
- [x] Ran the fixed script locally against fresh (unconfigured) Claude Desktop/Code config files — it now reaches the menu and successfully adds the `fl-studio` entry instead of exiting early

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of configuration status checks without changing the displayed status or subsequent menu behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->