### PR TITLE
Write colours as 0xRRGGBB, the layout FL's API uses

### DIFF
--- a/fl_controller/device_FLStudioMCP.py
+++ b/fl_controller/device_FLStudioMCP.py
@@ -431,8 +431,8 @@ def handle_mixer_set_track_color(params: dict) -> dict:
     r = params.get("r", 0)
     g = params.get("g", 0)
     b = params.get("b", 0)
-    # FL Studio uses BGR format
-    color = (b << 16) | (g << 8) | r
+    # FL Studio's scripting API takes 0xRRGGBB
+    color = (r << 16) | (g << 8) | b
     mixer.setTrackColor(track, color)
     return {"color": f"RGB({r}, {g}, {b})"}
 
@@ -607,8 +607,8 @@ def handle_channels_set_color(params: dict) -> dict:
     r = params.get("r", 0)
     g = params.get("g", 0)
     b = params.get("b", 0)
-    # FL Studio uses BGR format
-    color = (b << 16) | (g << 8) | r
+    # FL Studio's scripting API takes 0xRRGGBB
+    color = (r << 16) | (g << 8) | b
     channels.setChannelColor(index, color, True)
     return {"color": f"RGB({r}, {g}, {b})"}
 


### PR DESCRIPTION
Both colour setters swap red and blue. FL Studio's scripting API takes
`0xRRGGBB`, not `0xBBGGRR` as `handle_channels_set_color` and
`handle_mixer_set_track_color` assume, so the colour that reaches FL is the
requested one byte-reversed.

## Evidence

Measured on FL Studio 2026 (26.1.5), Linux/Wine.

`fl_set_channel_color(index=2, red=212, green=160, blue=72)` (amber) turns the
channel button **cyan**. A screen pixel probe on the button reads
`srgb(72,160,212)` — exactly the requested values with red and blue exchanged.

Passing them reversed, `red=72, green=160, blue=212`, produces the intended
amber, and `fl_get_channel_info(2)` then reports `-0x2b5fb8` = `0xFFD4A048` =
RGB(212,160,72).

The getters are already correct: `hex(channels.getChannelColor(...))` and
`hex(mixer.getTrackColor(...))` pass FL's value straight through, so they agree
with what is on screen while the setters do not. A set-then-read round trip
therefore disagrees with itself.

## After the change

Same session, same channel: `fl_set_channel_color(2, 220, 60, 40)` reads back
`-0x23c3d8` = `0xDC3C28`, and the button probes as `srgb(206,46,26)` — FL's own
shading of an unselected button, in the requested order. `fl_set_track_color(3,
40, 90, 220)` reads back `0x285ADC`.

## Note for the release notes

This changes observable behaviour for anyone who worked around the swap by
passing red and blue reversed.

Happy to add a regression test for the two handlers against the
`fl-studio-api-stubs` dev dependency if you would like one — I left it out
because the repo has no `tests/` directory yet and this is a four-line fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected track and channel color handling so RGB values are applied in the expected red-green-blue order.
  - Color values shown in responses remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
